### PR TITLE
Replace String with Classes for class prop fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { git = "https://github.com/jstarry/yew", branch = "component-children" }
+yew = { git = "https://github.com/yewstack/yew", branch = "master" }

--- a/src/components/col.rs
+++ b/src/components/col.rs
@@ -27,7 +27,7 @@ impl Component for Col {
 
 impl Renderable<Col> for Col {
     fn view(&self) -> Html<Self> {
-        let mut classes = self.props.class.extend("col");
+        let classes = self.props.class.clone().extend("col");
 
         html! {
             <div class=classes>

--- a/src/components/col.rs
+++ b/src/components/col.rs
@@ -1,14 +1,12 @@
 use yew::prelude::*;
 
-use crate::merge_classes;
-
 pub struct Col {
     props: Props,
 }
 
 #[derive(Properties)]
 pub struct Props {
-    pub class: String,
+    pub class: Classes,
     pub children: Children<Col>,
 }
 
@@ -29,9 +27,7 @@ impl Component for Col {
 
 impl Renderable<Col> for Col {
     fn view(&self) -> Html<Self> {
-        let mut classes = String::from("col");
-
-        classes = merge_classes(&classes, &self.props.class);
+        let mut classes = self.props.class.extend("col");
 
         html! {
             <div class=classes>

--- a/src/components/collapse.rs
+++ b/src/components/collapse.rs
@@ -30,7 +30,7 @@ impl Component for Collapse {
 
 impl Renderable<Collapse> for Collapse {
     fn view(&self) -> Html<Self> {
-        let mut classes = self.props.class.extend("collapse");
+        let mut classes = self.props.class.clone().extend("collapse");
 
         if self.props.navbar {
             classes.push("navbar-collapse");

--- a/src/components/collapse.rs
+++ b/src/components/collapse.rs
@@ -1,13 +1,11 @@
 use yew::prelude::*;
 
-use crate::merge_classes;
-
 #[derive(Properties)]
 pub struct Props {
     pub is_open: bool,
     pub navbar: bool,
 
-    pub class: String,
+    pub class: Classes,
     pub children: Children<Collapse>,
 }
 
@@ -32,17 +30,15 @@ impl Component for Collapse {
 
 impl Renderable<Collapse> for Collapse {
     fn view(&self) -> Html<Self> {
-        let mut classes = String::from("collapse");
+        let mut classes = self.props.class.extend("collapse");
 
         if self.props.navbar {
-            classes = merge_classes(&classes, "navbar-collapse");
+            classes.push("navbar-collapse");
         }
 
         if self.props.is_open {
-            classes = merge_classes(&classes, "show");
+            classes.push("show");
         }
-
-        classes = merge_classes(&classes, &self.props.class);
 
         html! {
             <div class=classes>

--- a/src/components/container.rs
+++ b/src/components/container.rs
@@ -30,13 +30,12 @@ impl Component for Container {
 
 impl Renderable<Container> for Container {
     fn view(&self) -> Html<Self> {
-        let mut classes = self.props.class.extend("container");
 
-        if self.props.fluid {
-            self.props.class.extend("container-fluid");
+        let classes = if self.props.fluid {
+            self.props.class.clone().extend("container-fluid")
         } else {
-            self.props.class.extend("container");
-        }
+            self.props.class.clone().extend("container")
+        };
 
         html! {
             <div class=classes>

--- a/src/components/container.rs
+++ b/src/components/container.rs
@@ -1,13 +1,11 @@
 use yew::html::Children;
 use yew::prelude::*;
 
-use crate::merge_classes;
-
 #[derive(Properties)]
 pub struct Props {
     pub fluid: bool,
 
-    pub class: String,
+    pub class: Classes,
     pub children: Children<Container>,
 }
 
@@ -32,13 +30,13 @@ impl Component for Container {
 
 impl Renderable<Container> for Container {
     fn view(&self) -> Html<Self> {
-        let mut classes = String::from("container");
+        let mut classes = self.props.class.extend("container");
 
         if self.props.fluid {
-            classes = format!("{}-fluid", classes);
+            self.props.class.extend("container-fluid");
+        } else {
+            self.props.class.extend("container");
         }
-
-        classes = merge_classes(&classes ,&self.props.class);
 
         html! {
             <div class=classes>

--- a/src/components/dropdown.rs
+++ b/src/components/dropdown.rs
@@ -1,8 +1,6 @@
 use yew::html::Children;
 use yew::prelude::*;
 
-use crate::merge_classes;
-
 #[derive(Properties)]
 pub struct Props {
     pub active: bool,
@@ -13,7 +11,7 @@ pub struct Props {
      * @FIXME Make this props resuable, optional, multitype children support needed
      * @TODO Add `dropdown-divider` as an child option
      */
-    pub class: String,
+    pub class: Classes,
     pub children: Children<Dropdown>,
 }
 
@@ -38,17 +36,15 @@ impl Component for Dropdown {
 
 impl Renderable<Dropdown> for Dropdown {
     fn view(&self) -> Html<Self> {
-        let mut classes = String::from("dropdown");
+        let mut classes = self.props.class.extend("dropdown");
 
         if self.props.nav {
-            classes = merge_classes(&classes, "nav-item");
+            classes.push("nav-item");
 
             if self.props.active {
-                classes = merge_classes(&classes, "active");
+                classes.push("active");
             }
         }
-
-        classes = merge_classes(&classes, &self.props.class);
 
         html! {
             <li class={classes}>

--- a/src/components/dropdown.rs
+++ b/src/components/dropdown.rs
@@ -36,11 +36,10 @@ impl Component for Dropdown {
 
 impl Renderable<Dropdown> for Dropdown {
     fn view(&self) -> Html<Self> {
-        let mut classes = self.props.class.extend("dropdown");
+        let mut classes = self.props.class.clone().extend("dropdown");
 
         if self.props.nav {
             classes.push("nav-item");
-
             if self.props.active {
                 classes.push("active");
             }

--- a/src/components/dropdown_divider.rs
+++ b/src/components/dropdown_divider.rs
@@ -1,10 +1,8 @@
 use yew::prelude::*;
 
-use crate::merge_classes;
-
 #[derive(Properties)]
 pub struct Props {
-    pub class: String,
+    pub class: Classes,
 }
 
 pub struct DropdownDivider {
@@ -28,7 +26,7 @@ impl Component for DropdownDivider {
 
 impl Renderable<DropdownDivider> for DropdownDivider {
     fn view(&self) -> Html<Self> {
-        let classes: String = merge_classes("dropdown-divider", &self.props.class);
+        let classes = self.props.class.extend("dropdown-divider");
 
         html! {
             <div class=classes></div>

--- a/src/components/dropdown_divider.rs
+++ b/src/components/dropdown_divider.rs
@@ -26,7 +26,7 @@ impl Component for DropdownDivider {
 
 impl Renderable<DropdownDivider> for DropdownDivider {
     fn view(&self) -> Html<Self> {
-        let classes = self.props.class.extend("dropdown-divider");
+        let classes = self.props.class.clone().clone().extend("dropdown-divider");
 
         html! {
             <div class=classes></div>

--- a/src/components/dropdown_item.rs
+++ b/src/components/dropdown_item.rs
@@ -30,7 +30,7 @@ impl Component for DropdownItem {
 
 impl Renderable<DropdownItem> for DropdownItem {
     fn view(&self) -> Html<Self> {
-        let classes = self.props.class.extend("dropdown-item");
+        let classes = self.props.class.clone().extend("dropdown-item");
 
         let mut href = String::from(&self.props.href);
 

--- a/src/components/dropdown_item.rs
+++ b/src/components/dropdown_item.rs
@@ -1,13 +1,11 @@
 use yew::html::Children;
 use yew::prelude::*;
 
-use crate::merge_classes;
-
 #[derive(Properties)]
 pub struct Props {
     pub href: String,
 
-    pub class: String,
+    pub class: Classes,
     pub children: Children<DropdownItem>,
 }
 
@@ -32,14 +30,13 @@ impl Component for DropdownItem {
 
 impl Renderable<DropdownItem> for DropdownItem {
     fn view(&self) -> Html<Self> {
-        let classes: String = merge_classes("dropdown-item", &self.props.class);
+        let classes = self.props.class.extend("dropdown-item");
 
         let mut href = String::from(&self.props.href);
 
         if href == "" {
             href = format!("#");
         }
-
 
         html! {
             <a class=classes href=href>

--- a/src/components/dropdown_menu.rs
+++ b/src/components/dropdown_menu.rs
@@ -1,12 +1,10 @@
 use yew::prelude::*;
 
-use crate::merge_classes;
-
 #[derive(Properties)]
 pub struct Props {
     pub is_open: bool,
 
-    pub class: String,
+    pub class: Classes,
     pub children: Children<DropdownMenu>,
 }
 
@@ -31,13 +29,11 @@ impl Component for DropdownMenu {
 
 impl Renderable<DropdownMenu> for DropdownMenu {
     fn view(&self) -> Html<Self> {
-        let mut classes = String::from("dropdown-menu");
+        let mut classes = self.props.class.extend("dropdown-menu");
 
         if self.props.is_open {
-            classes = merge_classes(&classes, "show");
+            classes.push("show");
         }
-
-        classes = merge_classes(&classes, &self.props.class);
 
         html! {
             <div class=classes  aria-labelledby="navbarDropdown">

--- a/src/components/dropdown_menu.rs
+++ b/src/components/dropdown_menu.rs
@@ -29,7 +29,7 @@ impl Component for DropdownMenu {
 
 impl Renderable<DropdownMenu> for DropdownMenu {
     fn view(&self) -> Html<Self> {
-        let mut classes = self.props.class.extend("dropdown-menu");
+        let mut classes = self.props.class.clone().extend("dropdown-menu");
 
         if self.props.is_open {
             classes.push("show");

--- a/src/components/dropdown_toggler.rs
+++ b/src/components/dropdown_toggler.rs
@@ -1,7 +1,5 @@
 use yew::prelude::*;
 
-use crate::merge_classes;
-
 pub struct DropdownToggler {
     props: Props,
 }
@@ -12,7 +10,7 @@ pub struct Props {
     pub nav: bool,
     // #[props(required)]
     // pub onclick: Callback<()>,
-    pub class: String,
+    pub class: Classes,
     pub children: Children<DropdownToggler>,
 }
 
@@ -40,16 +38,13 @@ impl Component for DropdownToggler {
 
 impl Renderable<DropdownToggler> for DropdownToggler {
     fn view(&self) -> Html<Self> {
-        let mut classes = String::new();
-
+        let mut classes = self.props.class.clone();
         if self.props.caret {
-            classes = merge_classes(&classes, "dropdown-toggle");
+            classes.extend("dropdown-toggle");
         }
         if self.props.nav {
-            classes = merge_classes(&classes, "nav-link");
+            classes.extend( "nav-link");
         }
-
-        classes = merge_classes(&classes, &self.props.class);
 
         html! {
             <a class=classes href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" onclick=|_| Msg::Toggle >

--- a/src/components/dropdown_toggler.rs
+++ b/src/components/dropdown_toggler.rs
@@ -40,10 +40,10 @@ impl Renderable<DropdownToggler> for DropdownToggler {
     fn view(&self) -> Html<Self> {
         let mut classes = self.props.class.clone();
         if self.props.caret {
-            classes.extend("dropdown-toggle");
+            classes.push("dropdown-toggle");
         }
         if self.props.nav {
-            classes.extend( "nav-link");
+            classes.push( "nav-link");
         }
 
         html! {

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -14,10 +14,6 @@ pub mod navbar_brand;
 pub mod navbar_toggler;
 pub mod row;
 
-pub fn merge_classes(class_a: &str, class_b: &str) -> String {
-    format!("{} {}", class_a, class_b)
-}
-
 pub use self::col::Col;
 pub use self::collapse::Collapse;
 pub use self::container::Container;

--- a/src/components/nav.rs
+++ b/src/components/nav.rs
@@ -30,9 +30,9 @@ impl Component for Nav {
 impl Renderable<Nav> for Nav {
     fn view(&self) -> Html<Self> {
         let classes: Classes = if self.props.navbar {
-            self.props.class.extend("navbar-nav")
+            self.props.class.clone().extend("navbar-nav")
         } else {
-            self.props.class.extend("nav")
+            self.props.class.clone().extend("nav")
         };
 
         html! {

--- a/src/components/nav.rs
+++ b/src/components/nav.rs
@@ -1,12 +1,10 @@
 use yew::prelude::*;
 
-use crate::merge_classes;
-
 #[derive(Properties)]
 pub struct Props {
     pub navbar: bool,
 
-    pub class: String,
+    pub class: Classes,
     pub children: Children<Nav>,
 }
 
@@ -31,12 +29,11 @@ impl Component for Nav {
 
 impl Renderable<Nav> for Nav {
     fn view(&self) -> Html<Self> {
-        let mut classes = String::from("nav");
-        if self.props.navbar {
-            classes = format!("navbar-{}", &classes);
-        }
-
-        classes = merge_classes(&classes, &self.props.class);
+        let classes: Classes = if self.props.navbar {
+            self.props.class.extend("navbar-nav")
+        } else {
+            self.props.class.extend("nav")
+        };
 
         html! {
             <ul class=classes>

--- a/src/components/nav_item.rs
+++ b/src/components/nav_item.rs
@@ -1,12 +1,10 @@
 use yew::prelude::*;
 
-use crate::merge_classes;
-
 #[derive(Properties)]
 pub struct Props {
     pub active: bool,
 
-    pub class: String,
+    pub class: Classes,
     pub children: Children<NavItem>,
 }
 
@@ -31,13 +29,10 @@ impl Component for NavItem {
 
 impl Renderable<NavItem> for NavItem {
     fn view(&self) -> Html<Self> {
-        let mut classes = String::from("nav-item");
-
+        let mut classes = self.props.class.extend("nav-link");
         if self.props.active {
-            classes = merge_classes(&classes, "active");
+            classes.push("active")
         }
-
-        classes = merge_classes(&classes, &self.props.class);
 
         html! {
             <li class=classes>

--- a/src/components/nav_item.rs
+++ b/src/components/nav_item.rs
@@ -29,7 +29,7 @@ impl Component for NavItem {
 
 impl Renderable<NavItem> for NavItem {
     fn view(&self) -> Html<Self> {
-        let mut classes = self.props.class.extend("nav-link");
+        let mut classes = self.props.class.clone().extend("nav-link");
         if self.props.active {
             classes.push("active")
         }

--- a/src/components/nav_link.rs
+++ b/src/components/nav_link.rs
@@ -1,14 +1,12 @@
 use yew::prelude::*;
 
-use crate::merge_classes;
-
 #[derive(Properties)]
 pub struct Props {
     pub active: bool,
     pub disabled: bool,
     pub href: String,
 
-    pub class: String,
+    pub class: Classes,
     pub children: Children<NavLink>,
 }
 
@@ -33,17 +31,13 @@ impl Component for NavLink {
 
 impl Renderable<NavLink> for NavLink {
     fn view(&self) -> Html<Self> {
-        let mut classes = String::from("nav-link");
-
+        let mut classes = self.props.class.extend("nav-link");
         if self.props.active {
-            classes = merge_classes(&classes, "active");
+            classes.push("active")
         }
-
         if self.props.disabled {
-            classes = merge_classes(&classes, "disabled");
+            classes.push("disabled")
         }
-
-        classes = merge_classes(&classes, &self.props.class);
 
         let mut href = String::from(&self.props.href);
 

--- a/src/components/nav_link.rs
+++ b/src/components/nav_link.rs
@@ -31,7 +31,7 @@ impl Component for NavLink {
 
 impl Renderable<NavLink> for NavLink {
     fn view(&self) -> Html<Self> {
-        let mut classes = self.props.class.extend("nav-link");
+        let mut classes = self.props.class.clone().extend("nav-link");
         if self.props.active {
             classes.push("active")
         }

--- a/src/components/navbar.rs
+++ b/src/components/navbar.rs
@@ -30,7 +30,7 @@ impl Component for Navbar {
 
 impl Renderable<Navbar> for Navbar {
     fn view(&self) -> Html<Self> {
-        let classes = self.props.class.extend("navbar navbar-expand-lg navbar-dark bg-dark"); // TODO is dark theming the navbar a good default behavior?
+        let classes = self.props.class.clone().extend("navbar navbar-expand-lg navbar-dark bg-dark"); // TODO is dark theming the navbar a good default behavior?
         html! {
             <nav class=classes>
                 { for (self.props.children).iter() }

--- a/src/components/navbar.rs
+++ b/src/components/navbar.rs
@@ -1,11 +1,9 @@
 use yew::html::Children;
 use yew::prelude::*;
 
-use crate::merge_classes;
-
 #[derive(Properties)]
 pub struct Props {
-    pub class: String,
+    pub class: Classes,
     pub children: Children<Navbar>,
 }
 
@@ -32,10 +30,7 @@ impl Component for Navbar {
 
 impl Renderable<Navbar> for Navbar {
     fn view(&self) -> Html<Self> {
-        let classes = merge_classes(
-            "navbar navbar-expand-lg navbar-dark bg-dark",
-            &self.props.class,
-        );
+        let classes = self.props.class.extend("navbar navbar-expand-lg navbar-dark bg-dark"); // TODO is dark theming the navbar a good default behavior?
         html! {
             <nav class=classes>
                 { for (self.props.children).iter() }

--- a/src/components/navbar_brand.rs
+++ b/src/components/navbar_brand.rs
@@ -1,7 +1,5 @@
 use yew::prelude::*;
 
-use crate::merge_classes;
-
 pub struct NavbarBrand {
     props: Props,
 }
@@ -10,7 +8,7 @@ pub struct NavbarBrand {
 pub struct Props {
     pub href: String,
 
-    pub class: String,
+    pub class: Classes,
     pub children: Children<NavbarBrand>,
 }
 
@@ -31,7 +29,7 @@ impl Component for NavbarBrand {
 
 impl Renderable<NavbarBrand> for NavbarBrand {
     fn view(&self) -> Html<Self> {
-        let classes = merge_classes("navbar-brand", &self.props.class);
+        let classes = self.props.class.extend("navbar-brand");
 
         let mut href = String::from(&self.props.href);
 

--- a/src/components/navbar_brand.rs
+++ b/src/components/navbar_brand.rs
@@ -29,7 +29,7 @@ impl Component for NavbarBrand {
 
 impl Renderable<NavbarBrand> for NavbarBrand {
     fn view(&self) -> Html<Self> {
-        let classes = self.props.class.extend("navbar-brand");
+        let classes = self.props.class.clone().extend("navbar-brand");
 
         let mut href = String::from(&self.props.href);
 

--- a/src/components/navbar_toggler.rs
+++ b/src/components/navbar_toggler.rs
@@ -36,7 +36,7 @@ impl Component for NavbarToggler {
 
 impl Renderable<NavbarToggler> for NavbarToggler {
     fn view(&self) -> Html<Self> {
-        let classes =  self.props.class.extend("navbar-toggler");
+        let classes =  self.props.class.clone().extend("navbar-toggler");
 
         html! {
             <button class=classes type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="true" aria-label="Toggle navigation"

--- a/src/components/navbar_toggler.rs
+++ b/src/components/navbar_toggler.rs
@@ -1,7 +1,5 @@
 use yew::prelude::*;
 
-use crate::merge_classes;
-
 pub struct NavbarToggler {
     props: Props,
 }
@@ -10,7 +8,7 @@ pub struct NavbarToggler {
 pub struct Props {
     // #[props(required)]
     // pub onclick: Callback<()>,
-    pub class: String,
+    pub class: Classes,
     pub children: Children<NavbarToggler>,
 }
 
@@ -38,7 +36,7 @@ impl Component for NavbarToggler {
 
 impl Renderable<NavbarToggler> for NavbarToggler {
     fn view(&self) -> Html<Self> {
-        let classes = merge_classes("navbar-toggler", &self.props.class);
+        let classes =  self.props.class.extend("navbar-toggler");
 
         html! {
             <button class=classes type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="true" aria-label="Toggle navigation"

--- a/src/components/row.rs
+++ b/src/components/row.rs
@@ -31,7 +31,7 @@ impl Component for Row {
 
 impl Renderable<Row> for Row {
     fn view(&self) -> Html<Self> {
-        let classes = self.props.class.extend("row");
+        let classes = self.props.class.clone().extend("row");
 
         html! {
             <div class=classes>

--- a/src/components/row.rs
+++ b/src/components/row.rs
@@ -1,14 +1,12 @@
 // use yew::html::Children;
 use yew::prelude::*;
 
-use crate::merge_classes;
-
 #[derive(Properties)]
 pub struct Props {
     // noGutters: bool,
     // form: bool,
     
-    pub class: String,
+    pub class: Classes,
     pub children: Children<Row>,
 }
 
@@ -33,7 +31,7 @@ impl Component for Row {
 
 impl Renderable<Row> for Row {
     fn view(&self) -> Html<Self> {
-        let classes = merge_classes("row", &self.props.class);
+        let classes = self.props.class.extend("row");
 
         html! {
             <div class=classes>


### PR DESCRIPTION
This replaces String with Class for the class fields in props.
Closes #1 

------

Currently this won't compile because `Classes` doesn't implement `Default` in yew required to implement  `Properties` for the many `Props`.
A PR will be opened in Yew momentarily to address this problem.
This error is likely also hiding errors related to missing 'clones()', but that should be easy to address once `Classes` gets its `Default`.